### PR TITLE
fix(WEBRTC-2120): Enable PSTN calls via early SDP integration with MEDIA message

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/lib/main_view_model.dart
+++ b/lib/main_view_model.dart
@@ -19,6 +19,9 @@ class MainViewModel with ChangeNotifier {
   bool _ongoingCall = false;
   IncomingInviteParams? _incomingInvite;
 
+  String _localName = '';
+  String _localNumber = '';
+
   bool get registered {
     return _registered;
   }
@@ -108,13 +111,15 @@ class MainViewModel with ChangeNotifier {
   }
 
   void login(CredentialConfig credentialConfig) {
+    _localName = credentialConfig.sipCallerIDName;
+    _localNumber = credentialConfig.sipCallerIDNumber;
     _telnyxClient.credentialLogin(credentialConfig);
   }
 
   void call(String destination) {
     _telnyxClient
         .createCall()
-        .newInvite("callerName", "+353877189671", destination, "Fake State");
+        .newInvite(_localName, _localNumber, destination, "Fake State");
   }
 
   void accept() {

--- a/lib/main_view_model.dart
+++ b/lib/main_view_model.dart
@@ -125,7 +125,7 @@ class MainViewModel with ChangeNotifier {
   void accept() {
     if (_incomingInvite != null) {
       _telnyxClient.createCall().acceptCall(
-          _incomingInvite!, "callerName", "+353877189671", "Fake State");
+          _incomingInvite!, _localName, _localNumber, "Fake State");
       _ongoingInvitation = false;
       _ongoingCall = true;
       notifyListeners();

--- a/lib/main_view_model.dart
+++ b/lib/main_view_model.dart
@@ -114,13 +114,13 @@ class MainViewModel with ChangeNotifier {
   void call(String destination) {
     _telnyxClient
         .createCall()
-        .newInvite("callerName", "Fake Number", destination, "Fake State");
+        .newInvite("callerName", "+353877189671", destination, "Fake State");
   }
 
   void accept() {
     if (_incomingInvite != null) {
       _telnyxClient.createCall().acceptCall(
-          _incomingInvite!, "callerName", "Fake Number", "Fake State");
+          _incomingInvite!, "callerName", "+353877189671", "Fake State");
       _ongoingInvitation = false;
       _ongoingCall = true;
       notifyListeners();

--- a/packages/telnyx_webrtc/CHANGELOG.md
+++ b/packages/telnyx_webrtc/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.5
+
+- Enable PSTN call integration via early SDP contained in Telnyx Media Message
+- Fixed ICE candidate error that would add a local IP ICE Candidate
+
 ## 0.0.4
 
 - Improved stability by providing session ID to backend rather than waiting and setting one

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -82,10 +82,7 @@ class Call {
         sessid: _sessid);
 
     var byeMessage = SendByeMessage(
-        id: uuid,
-        jsonrpc: "2.0",
-        method: SocketMethod.BYE,
-        params: byeParams);
+        id: uuid, jsonrpc: "2.0", method: SocketMethod.BYE, params: byeParams);
 
     String jsonByeMessage = jsonEncode(byeMessage);
     _txSocket.send(jsonByeMessage);
@@ -112,8 +109,8 @@ class Call {
         userVariables: [],
         video: false);
 
-    var infoParams = InfoParams(
-        dialogParams: dialogParams, dtmf: tone, sessid: _sessid);
+    var infoParams =
+        InfoParams(dialogParams: dialogParams, dtmf: tone, sessid: _sessid);
 
     var dtmfMessageBody = DtmfInfoMessage(
         id: uuid,

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:telnyx_webrtc/model/jsonrpc.dart';
+
 import '/model/socket_method.dart';
 import '/model/verto/receive/received_message_body.dart';
 import '/model/verto/send/send_bye_message_body.dart';
@@ -82,7 +84,10 @@ class Call {
         sessid: _sessid);
 
     var byeMessage = SendByeMessage(
-        id: uuid, jsonrpc: "2.0", method: SocketMethod.BYE, params: byeParams);
+        id: uuid,
+        jsonrpc: JsonRPCConstant.jsonrpc,
+        method: SocketMethod.BYE,
+        params: byeParams);
 
     String jsonByeMessage = jsonEncode(byeMessage);
     _txSocket.send(jsonByeMessage);
@@ -114,7 +119,7 @@ class Call {
 
     var dtmfMessageBody = DtmfInfoMessage(
         id: uuid,
-        jsonrpc: "2.0",
+        jsonrpc: JsonRPCConstant.jsonrpc,
         method: SocketMethod.INFO,
         params: infoParams);
 
@@ -162,7 +167,7 @@ class Call {
         id: uuid.toString(),
         method: SocketMethod.MODIFY,
         params: modifyParams,
-        jsonrpc: "2.0");
+        jsonrpc: JsonRPCConstant.jsonrpc);
 
     String jsonModifyMessage = jsonEncode(modifyMessage);
     _txSocket.send(jsonModifyMessage);

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -36,7 +36,7 @@ class Call {
     sessionDestinationNumber = destinationNumber;
     sessionClientState = clientState;
 
-    callId = const Uuid().toString();
+    callId = const Uuid().v4();
     var base64State = base64.encode(utf8.encode(clientState));
 
     peerConnection = Peer(_txSocket);
@@ -72,7 +72,7 @@ class Call {
 
   /// Attempts to end the call identified via the [callID]
   void endCall(String? callID) {
-    var uuid = const Uuid();
+    var uuid = const Uuid().v4();
     var byeDialogParams = ByeDialogParams(callId: callID);
 
     var byeParams = SendByeParams(
@@ -82,7 +82,7 @@ class Call {
         sessid: _sessid);
 
     var byeMessage = SendByeMessage(
-        id: uuid.toString(),
+        id: uuid,
         jsonrpc: "2.0",
         method: SocketMethod.BYE,
         params: byeParams);
@@ -97,7 +97,7 @@ class Call {
   /// Sends a DTMF message with the chosen [tone] to the call
   /// specified via the [callID]
   void dtmf(String? callID, String tone) {
-    var uuid = const Uuid();
+    var uuid = const Uuid().v4();
     var dialogParams = DialogParams(
         attach: false,
         audio: true,
@@ -116,7 +116,7 @@ class Call {
         dialogParams: dialogParams, dtmf: tone, sessid: _sessid);
 
     var dtmfMessageBody = DtmfInfoMessage(
-        id: uuid.toString(),
+        id: uuid,
         jsonrpc: "2.0",
         method: SocketMethod.INFO,
         params: infoParams);
@@ -143,7 +143,7 @@ class Call {
   }
 
   void _sendHoldModifier(String action) {
-    var uuid = const Uuid();
+    var uuid = const Uuid().v4();
     var dialogParams = DialogParams(
         attach: false,
         audio: true,

--- a/packages/telnyx_webrtc/lib/model/jsonrpc.dart
+++ b/packages/telnyx_webrtc/lib/model/jsonrpc.dart
@@ -1,0 +1,3 @@
+class JsonRPCConstant {
+  static const jsonrpc = "2.0";
+}

--- a/packages/telnyx_webrtc/lib/model/verto/send/send_bye_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/send/send_bye_message_body.dart
@@ -34,8 +34,7 @@ class SendByeParams {
   ByeDialogParams? dialogParams;
   String? sessid;
 
-  SendByeParams(
-      {this.cause, this.causeCode, this.dialogParams, this.sessid});
+  SendByeParams({this.cause, this.causeCode, this.dialogParams, this.sessid});
 
   SendByeParams.fromJson(Map<String, dynamic> json) {
     cause = json['cause'];

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -130,8 +130,8 @@ class Peer {
       if (session.remoteCandidates.isNotEmpty) {
         for (var candidate in session.remoteCandidates) {
           if (candidate.candidate != null) {
-              _logger.i("adding $candidate");
-              await session.peerConnection?.addCandidate(candidate);
+            _logger.i("adding $candidate");
+            await session.peerConnection?.addCandidate(candidate);
           }
         }
         session.remoteCandidates.clear();
@@ -333,7 +333,7 @@ class Peer {
 
     peerConnection.onIceConnectionState = (state) {
       _logger.i("Peer :: ICE Connection State change :: $state");
-      switch (state){
+      switch (state) {
         case RTCIceConnectionState.RTCIceConnectionStateFailed:
           peerConnection.restartIce();
           return;

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -12,6 +12,8 @@ import 'package:logger/logger.dart';
 
 import 'package:telnyx_webrtc/model/verto/receive/received_message_body.dart';
 
+import '../model/jsonrpc.dart';
+
 enum SignalingState {
   ConnectionOpen,
   ConnectionClosed,
@@ -165,7 +167,7 @@ class Peer {
             userAgent: "Flutter-1.0");
         var inviteMessage = InviteAnswerMessage(
             id: const Uuid().toString(),
-            jsonrpc: "2.0",
+            jsonrpc: JsonRPCConstant.jsonrpc,
             method: SocketMethod.INVITE,
             params: inviteParams);
 
@@ -252,7 +254,7 @@ class Peer {
             userAgent: "Flutter-1.0");
         var answerMessage = InviteAnswerMessage(
             id: const Uuid().toString(),
-            jsonrpc: "2.0",
+            jsonrpc: JsonRPCConstant.jsonrpc,
             method: SocketMethod.ANSWER,
             params: inviteParams);
 

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -17,6 +17,8 @@ import 'package:telnyx_webrtc/tx_socket.dart'
 import 'package:uuid/uuid.dart';
 import 'package:flutter/foundation.dart';
 
+import 'model/jsonrpc.dart';
+
 typedef OnSocketMessageReceived = void Function(TelnyxMessage message);
 typedef OnSocketErrorReceived = void Function(TelnyxSocketError message);
 
@@ -155,7 +157,7 @@ class TelnyxClient {
         id: uuid,
         method: SocketMethod.LOGIN,
         params: loginParams,
-        jsonrpc: "2.0");
+        jsonrpc: JsonRPCConstant.jsonrpc);
 
     String jsonLoginMessage = jsonEncode(loginMessage);
 
@@ -188,7 +190,7 @@ class TelnyxClient {
         id: uuid,
         method: SocketMethod.LOGIN,
         params: loginParams,
-        jsonrpc: "2.0");
+        jsonrpc: JsonRPCConstant.jsonrpc);
 
     String jsonLoginMessage = jsonEncode(loginMessage);
 
@@ -487,7 +489,7 @@ class TelnyxClient {
           id: uuid.toString(),
           method: SocketMethod.GATEWAY_STATE,
           params: gatewayRequestParams,
-          jsonrpc: "2.0");
+          jsonrpc: JsonRPCConstant.jsonrpc);
 
       String jsonGatewayRequestMessage = jsonEncode(gatewayRequestMessage);
 

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -32,7 +32,7 @@ class TelnyxClient {
   final _logger = Logger();
 
   /// The current session ID related to this client
-  String sessid = const Uuid().toString();
+  String sessid = const Uuid().v4();
 
   /// The current instance of [Call] associated with this client. Can be used
   /// to call call related functions such as hold/mute
@@ -128,7 +128,7 @@ class TelnyxClient {
   /// May return a [TelnyxSocketError] in the case of an authentication error
   void credentialLogin(CredentialConfig config) {
     storedCredentialConfig = config;
-    var uuid = const Uuid();
+    var uuid = const Uuid().v4();
     var user = config.sipUser;
     var password = config.sipPassword;
     var fcmToken = config.notificationToken;
@@ -149,7 +149,7 @@ class TelnyxClient {
         loginParams: [],
         userVariables: notificationParams);
     var loginMessage = LoginMessage(
-        id: uuid.toString(),
+        id: uuid,
         method: SocketMethod.LOGIN,
         params: loginParams,
         jsonrpc: "2.0");
@@ -165,7 +165,7 @@ class TelnyxClient {
   /// May return a [TelnyxSocketError] in the case of an authentication error
   void tokenLogin(TokenConfig config) {
     storedTokenConfig = config;
-    var uuid = const Uuid();
+    var uuid = const Uuid().v4();
     var token = config.sipToken;
     var fcmToken = config.notificationToken;
     UserVariables? notificationParams;
@@ -182,7 +182,7 @@ class TelnyxClient {
     var loginParams = LoginParams(
         loginToken: token, loginParams: [], userVariables: notificationParams);
     var loginMessage = LoginMessage(
-        id: uuid.toString(),
+        id: uuid,
         method: SocketMethod.LOGIN,
         params: loginParams,
         jsonrpc: "2.0");
@@ -310,6 +310,7 @@ class TelnyxClient {
                 _logger.i('RINGING RECEIVED :: $messageJson');
                 ReceivedMessage ringing =
                     ReceivedMessage.fromJson(jsonDecode(data.toString()));
+                _logger.i('Telnyx Leg ID :: ${ringing.inviteParams?.telnyxLegId.toString()}');
                 var message = TelnyxMessage(
                     socketMethod: SocketMethod.RINGING, message: ringing);
                 onSocketMessageReceived(message);

--- a/packages/telnyx_webrtc/lib/tx_socket_web.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket_web.dart
@@ -19,9 +19,9 @@ class TxSocket {
   late OnMessageCallback onMessage;
   late OnCloseCallback onClose;
 
-  connect(String providedHostAddress) async {
+  connect() async {
     try {
-      _socket = WebSocket(providedHostAddress);
+      _socket = WebSocket(hostAddress);
       _socket.onOpen.listen((e) {
         onOpen.call();
       });

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_lints: ^2.0.1
-  flutter_webrtc: ^0.8.12
+  flutter_webrtc: ^0.9.5
   logger: ^1.1.0
   uuid: ^3.0.6
   mockito: ^5.2.0

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -3,7 +3,7 @@ description: Enable real-time communication with WebRTC and Telnyx. Create and r
 homepage: https://telnyx.com/
 repository: https://github.com/team-telnyx/telnyx-webrtc-flutter
 issue_tracker: https://github.com/team-telnyx/telnyx-webrtc-flutter/issues?q=is%3Aopen+is%3Aissue
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ">=2.16.2 <3.0.0"


### PR DESCRIPTION
[WEBRTC-2120 - Flutter Audio issue on PSTN calls.](https://telnyx.atlassian.net/browse/WEBRTC-2120)

---
<!-- Describe your changes here -->
This PR fixes an issue where SDPs that were being sent early via a MEDIA message were being ignored. This happens ins rare occasions - one such occasion though is PSTN calls to real device sim cards. 

The error that was occurring was that we were expecting an SDP in the ANSWER message which is what happens in most cases. Effectively we were setting te remote SDP as a null string.

We now check for Media messages first and if they contain an SDP we set the remote SDP with that and then send the call socket message once we have received Answer afterwards.

We also do a check on ICE Candidates to make sure we aren't adding a local IP Ice Candidate. This is an issue with the Flutter WebRTC library we are using. 

## :older_man: :baby: Behaviors
### Before changes
- Not handling early SDPs in media messages
- Adding local IP Ice Candidate which can result in no Audio (not a valid Ice Candidate if it is chosen)

### After changes
- Early SDP logic to set SDP contained in Media Message before we receive ANSWER (that won't contain SDP in this case)
- Check ICE candidates as they come in before adding them, if they contain '127.0.0.1' we skip. 
- Dependency bumps
- Sample app now uses provided name and number during login for a call, rather than hardcoded values

## ✋ Manual testing
1. Log into application with SIP connection
2. Call a PSTN number
3. Should work as expected
